### PR TITLE
Increment file name when rotating to a new capture file.

### DIFF
--- a/src/exact-capture-writer.c
+++ b/src/exact-capture-writer.c
@@ -428,7 +428,7 @@ void* writer_thread (void* params)
         {
             eio_des (ostream);
             if (open_file (dest, wparams->dummy_ostream, &ostream,
-                           istreams[curr_istream].file_id ))
+                           ++istreams[curr_istream].file_id ))
             {
                 ch_log_error("Could not open new output file\n");
                 goto finished;


### PR DESCRIPTION
Currently, using the -m option results in each subsequent file overwriting the previous one. Incrementing the file's id does the trick.
