### PR TITLE
Fix file ID increment for file rotation

### DIFF
--- a/src/exact-capture-writer.c
+++ b/src/exact-capture-writer.c
@@ -192,6 +192,7 @@ void* writer_thread (void* params)
     {
         istreams[iface_idx].dev_id   = wparams->exanic_dev_id[iface_idx];
         istreams[iface_idx].port_num = wparams->exanic_port_id[iface_idx];
+        istreams[iface_idx].file_id  = 1; 
 
         const char* iface = ifaces->first[iface_idx];
 
@@ -434,6 +435,7 @@ void* writer_thread (void* params)
                 goto finished;
             }
             bytes_written = 0;
+            istreams[curr_istream].file_id++;
         }
     }
 


### PR DESCRIPTION
File rotation ID was not initialised and was not incrementing after each file open.