### PR TITLE
Fixed max file option, tcpdump alignment

### DIFF
--- a/src/exact-capture-writer.c
+++ b/src/exact-capture-writer.c
@@ -417,8 +417,6 @@ void* writer_thread (void* params)
         /* Release the istream */
         eio_stream_t* istream = istreams[curr_istream].istream;
         eio_rd_rel (istream, NULL);
-        /* Make sure we look at the next ring next time for fairness */
-        curr_istream++;
 
         /*  Stats */
         stats->dbytes += rd_buff_len;
@@ -427,6 +425,7 @@ void* writer_thread (void* params)
         ifunlikely(max_file_size > 0 && bytes_written >= max_file_size)
         {
             eio_des (ostream);
+            istreams[curr_istream].file_id++;
             if (open_file (dest, wparams->dummy_ostream, &ostream,
                            istreams[curr_istream].file_id ))
             {
@@ -435,6 +434,9 @@ void* writer_thread (void* params)
             }
             bytes_written = 0;
         }
+
+        /* Make sure we look at the next ring next time for fairness */
+        curr_istream++;
     }
 
     finished:

--- a/src/exact-capture.c
+++ b/src/exact-capture.c
@@ -1004,7 +1004,7 @@ int main (int argc, char** argv)
     remove_dups(options.dests);
 
 
-    max_file_size = options.max_file;
+    max_file_size = options.max_file * 1000 * 1000;
     max_pkt_len = options.snaplen;
     min_pcap_rec = MIN(sizeof(pcap_pkthdr_t) + sizeof(expcap_pktftr_t),MIN_ETH_PKT);
     max_pcap_rec = min_pcap_rec + max_pkt_len;

--- a/src/exact-capture.c
+++ b/src/exact-capture.c
@@ -1004,7 +1004,7 @@ int main (int argc, char** argv)
     remove_dups(options.dests);
 
 
-    max_file_size = options.max_file * 1000 * 1000;
+    max_file_size = options.max_file;
     max_pkt_len = options.snaplen;
     min_pcap_rec = MIN(sizeof(pcap_pkthdr_t) + sizeof(expcap_pktftr_t),MIN_ETH_PKT);
     max_pcap_rec = min_pcap_rec + max_pkt_len;


### PR DESCRIPTION
curr_istream index was incremented before its final usage.
file_id was never incremented elsewhere.

I've also brought the max_file parameter's usage inline with tcpdump's -C option.