### PR TITLE
fix GCC compile warning when accessing address of packed struct member

### DIFF
--- a/tools/data_structs/vlan_ethhdr.h
+++ b/tools/data_structs/vlan_ethhdr.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 typedef struct vlan_ethhdr {
     uint64_t            h_dest : 48;
     uint64_t    	h_source : 48;


### PR DESCRIPTION
This change fixes a compiler warning raised because pcap_modify would access the address of a packed struct member.

```
warning: converting a packed ‘struct ethhdr’ pointer (alignment 1) to a ‘struct vlan_ethhdr’ pointer (alignment 2) may result in an unaligned pointer value [-Waddress-of-packed-member]
```

I've resolved this by using a temporary variable instead and copying the temp variable back to the struct.

This didn't actually cause a functional issue with pcap_modify, but it's preferable to not have the compiler warning appear.