### PR TITLE
Fix extract merge

### DIFF
--- a/tools/data_structs/pcap_buff.c
+++ b/tools/data_structs/pcap_buff.c
@@ -46,18 +46,11 @@ buff_error_t pcap_buff_from_file(pcap_buff_t* pcap_buff, char* filename)
     return BUFF_ENONE;
 }
 
-pkt_info_t pcap_buff_next_packet(pcap_buff_t* pcap_buff)
+pkt_info_t pcap_buff_get_info(pcap_buff_t *pcap_buff)
 {
-    pcap_pkthdr_t* curr_hdr = pcap_buff->hdr;
-
-    if(curr_hdr == NULL){
+    if(pcap_buff->hdr == NULL){
         pcap_buff->hdr = (pcap_pkthdr_t*)(pcap_buff->_buff->data + sizeof(pcap_file_header_t));
         pcap_buff->idx = 0;
-    } else {
-        const int64_t curr_cap_len = curr_hdr->caplen;
-        pcap_pkthdr_t* next_hdr = (pcap_pkthdr_t*)((char*)(curr_hdr+1) + curr_cap_len);
-        pcap_buff->hdr = next_hdr;
-        pcap_buff->idx++;
     }
 
     pcap_buff->pkt = (char*)(pcap_buff->hdr + 1);
@@ -101,6 +94,23 @@ pkt_info_t pcap_buff_next_packet(pcap_buff_t* pcap_buff)
     }
 
     return PKT_OK;
+}
+
+pkt_info_t pcap_buff_next_packet(pcap_buff_t* pcap_buff)
+{
+    pcap_pkthdr_t* curr_hdr = pcap_buff->hdr;
+
+    if(curr_hdr == NULL){
+        pcap_buff->hdr = (pcap_pkthdr_t*)(pcap_buff->_buff->data + sizeof(pcap_file_header_t));
+        pcap_buff->idx = 0;
+    } else {
+        const int64_t curr_cap_len = curr_hdr->caplen;
+        pcap_pkthdr_t* next_hdr = (pcap_pkthdr_t*)((char*)(curr_hdr+1) + curr_cap_len);
+        pcap_buff->hdr = next_hdr;
+        pcap_buff->idx++;
+    }
+
+    return pcap_buff_get_info(pcap_buff);
 }
 
 bool pcap_buff_eof(pcap_buff_t* pcap_buff)

--- a/tools/data_structs/pcap_buff.c
+++ b/tools/data_structs/pcap_buff.c
@@ -46,7 +46,7 @@ buff_error_t pcap_buff_from_file(pcap_buff_t* pcap_buff, char* filename)
     return BUFF_ENONE;
 }
 
-pkt_info_t pcap_buff_get_info(pcap_buff_t *pcap_buff)
+pkt_info_t pcap_buff_get_info(pcap_buff_t* pcap_buff)
 {
     if(pcap_buff->hdr == NULL){
         pcap_buff->hdr = (pcap_pkthdr_t*)(pcap_buff->_buff->data + sizeof(pcap_file_header_t));

--- a/tools/data_structs/pcap_buff.h
+++ b/tools/data_structs/pcap_buff.h
@@ -30,9 +30,12 @@ buff_error_t pcap_buff_init(char* filename, int64_t snaplen, int64_t max_filesiz
 
 /* Read in a pcap from disk. */
 /* The underlying buff is read only */
-buff_error_t pcap_buff_from_file(pcap_buff_t* pcap_buff, char* filename);
+buff_error_t pcap_buff_from_file(pcap_buff_t *pcap_buff, char *filename);
 
-/* Adjust hdr, data, idx, ftr to point to the next packet */
+/* Return information about the current packet */
+pkt_info_t pcap_buff_get_info(pcap_buff_t *pcap_buff);
+
+/* Adjust hdr, data, idx, ftr to point to the next packet and return packet information */
 pkt_info_t pcap_buff_next_packet(pcap_buff_t* pcap_buff);
 
 /* Get the filename used by the buff_t. */

--- a/tools/data_structs/pcap_buff.h
+++ b/tools/data_structs/pcap_buff.h
@@ -30,10 +30,10 @@ buff_error_t pcap_buff_init(char* filename, int64_t snaplen, int64_t max_filesiz
 
 /* Read in a pcap from disk. */
 /* The underlying buff is read only */
-buff_error_t pcap_buff_from_file(pcap_buff_t *pcap_buff, char *filename);
+buff_error_t pcap_buff_from_file(pcap_buff_t* pcap_buff, char* filename);
 
 /* Return information about the current packet */
-pkt_info_t pcap_buff_get_info(pcap_buff_t *pcap_buff);
+pkt_info_t pcap_buff_get_info(pcap_buff_t* pcap_buff);
 
 /* Adjust hdr, data, idx, ftr to point to the next packet and return packet information */
 pkt_info_t pcap_buff_next_packet(pcap_buff_t* pcap_buff);


### PR DESCRIPTION
Switching on pcap_buff_next_packet incremented the packet index for each read buffer before the timestamp comparison was performed. This would break merge behavior, since the index of all buffers would be incremented every iteration, rather than just the buffer which had the earliest timestamp on a given iteration.

Instead, exact_pcap_extract must switch on a new interface added to pcap_buff, pcap_buff_get_info(). This allows users to inspect the current packet of a pcap_buff and return information about that packet without causing the pcap_buff to point to the next packet.

As pcap_buff_next_packet has not been changed, the other tools which still rely on that functionality are unchanged by the addition of the new interface.